### PR TITLE
Add customizable report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Bob-Sponja
+# Bob-Sponja Report Generator
+
+This repository contains a simple Python script for generating customizable text reports.
+
+## Usage
+
+```bash
+python report_generator.py \
+    --title "My Report" \
+    --author "Seu Nome" \
+    --section "Introducao:Este e o texto de introducao" \
+    --section "Resultados:Os resultados estao aqui" \
+    --output meu_relatorio.txt
+```
+
+The script accepts multiple `--section` arguments, each in the format `"Titulo:Conteudo"`. The generated report is saved to the file provided via `--output`.

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,0 +1,62 @@
+import argparse
+from datetime import date
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate customizable text reports.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--title", default="Untitled Report", help="Report title")
+    parser.add_argument("--author", default="Anonymous", help="Author name")
+    parser.add_argument(
+        "--date",
+        default=date.today().isoformat(),
+        help="Date to display in the report (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--section",
+        action="append",
+        default=[],
+        help="Sections in the form 'Title:Content'. Can be used multiple times.",
+    )
+    parser.add_argument(
+        "--output",
+        default="report.txt",
+        help="Path of the generated report file",
+    )
+    return parser.parse_args()
+
+
+def parse_sections(section_args):
+    sections = []
+    for entry in section_args:
+        if ":" in entry:
+            title, content = entry.split(":", 1)
+        else:
+            title, content = entry, ""
+        sections.append((title.strip(), content.strip()))
+    return sections
+
+
+def generate_report(title, author, report_date, sections):
+    lines = [f"# {title}", f"Author: {author}", f"Date: {report_date}", ""]
+    for sec_title, sec_content in sections:
+        lines.append(f"## {sec_title}")
+        if sec_content:
+            lines.append(sec_content)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    args = parse_args()
+    sections = parse_sections(args.section)
+    report = generate_report(args.title, args.author, args.date, sections)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(report)
+    print(f"Report generated at {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script `report_generator.py` that builds text reports from CLI options
- update README with usage instructions for the new generator

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `python report_generator.py --title Test --author TestUser --section "Intro:This is the intro" --output test_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_68548e8116b8832fb44a3154483d513e